### PR TITLE
chore: fix release-drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,36 +1,60 @@
-name-template: "v$RESOLVED_VERSION 🌈"
-tag-template: "v$RESOLVED_VERSION"
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: "🚀 Features"
+  - title: '🚀 Features'
     labels:
-      - "feat"
-      - "feature"
-      - "enhancement"
-  - title: "🐛 Bug Fixes"
+      - 'feat'
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
     labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
-  - title: "📝 Documentation"
-    label: "docs"
-  - title: "🧰 Maintenance"
-    label: "chore"
-  - title: "🌀 Miscellaneous"
-    label: "misc"
-change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📝 Documentation'
+    label: 'docs'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '🌀 Miscellaneous'
+    label: 'misc'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
-      - "major"
+      - 'major'
   minor:
     labels:
-      - "minor"
+      - 'minor'
   patch:
     labels:
-      - "patch"
+      - 'patch'
   default: minor
 template: |
   ## Changes
 
   $CHANGES
+autolabeler:
+  - label: 'feat'
+    branch:
+      - '/^feat\/.+/'
+    title:
+      - '/^feat(\(.+\))?:/i'
+  - label: 'fix'
+    branch:
+      - '/^fix\/.+/'
+    title:
+      - '/^fix(\(.+\))?:/i'
+  - label: 'docs'
+    branch:
+      - '/^docs?\/.+/'
+    title:
+      - '/^docs?(\(.+\))?:/i'
+  - label: 'chore'
+    branch:
+      - '/^chore\/.+/'
+    title:
+      - '/^chore(\(.+\))?:/i'
+  - label: 'misc'
+    branch:
+      - '/^misc\/.+/'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,6 +40,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,37 +1,45 @@
 name: Release Drafter
 
 on:
-    push:
-        # branches to consider in the event; optional, defaults to all
-        branches:
-            - main
-    # # pull_request event is required only for autolabeler
-    # pull_request:
-    #   # Only following types are handled by the action, but one can default to all as well
-    #   types: [opened, reopened, synchronize]
-    # pull_request_target event is required for autolabeler to support PRs from forks
-    pull_request_target:
-        types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
 
+# Minimal default — each job overrides what it needs
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    update_release_draft:
-        permissions:
-            # write permission is required to create a github release
-            contents: write
-            # write permission is required for autolabeler
-            # otherwise, read permission is required at least
-            pull-requests: write
-        runs-on: ubuntu-latest
-        steps:
-            # Drafts your next Release notes as Pull Requests are merged into "master"
-            - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-              with:
-                egress-policy: audit
+  update_release_draft:
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
 
-            - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: release-drafter/release-drafter@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto_label:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove `pull_request_target` trigger, split into two conditional jobs (`update_release_draft` on push, `auto_label` on pull_request), fix permissions, and add harden-runner to both jobs.