### PR TITLE
chore: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,18 @@ updates:
       go:
         patterns:
           - "*"
+
+  # Maintain version for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "friday"
+      time: "00:30"
+    target-branch: "main"
+    assignees:
+      - "hibare"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add missing docker ecosystem entry (docker-compose.dev.yml present in repo).