### PR TITLE
chore: fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -12,12 +12,16 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
       - id: check-shebang-scripts-are-executable
+
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: bf2137dcd61fa219107613e4a4103cf24540cd93 # v1.0.0-rc.2
+    rev: v1.0.0-rc.4
     hooks:
       - id: go-mod-tidy
+      - id: go-fmt
       - id: go-test-mod
       - id: golangci-lint-mod
+        args: [--fix]
+
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:


### PR DESCRIPTION
Update pre-commit hooks: migrate from unmaintained dnephin/pre-commit-golang to tekwizely, upgrade stale hook revisions, and fix missing/stale hooks.